### PR TITLE
Enable IBM Cloud User Key

### DIFF
--- a/pkg/detectors/ibmclouduserkey/ibmclouduserkey.go
+++ b/pkg/detectors/ibmclouduserkey/ibmclouduserkey.go
@@ -2,72 +2,24 @@ package ibmclouduserkey
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{}
+type Scanner struct {
+	client *http.Client
+}
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
-
-var (
-	client = common.SaneHttpClient()
-
-	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"ibm"}) + `\b([A-Za-z0-9_-]{44})\b`)
-)
-
-// Keywords are used for efficiently pre-filtering chunks.
-// Use identifiers in the secret preferably, or the provider name.
-func (s Scanner) Keywords() []string {
-	return []string{"ibm"}
-}
-
-// FromData will find and optionally verify IbmCloudUserKey secrets in a given set of bytes.
-func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
-	dataStr := string(data)
-
-	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
-
-	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
-		resMatch := strings.TrimSpace(match[1])
-
-		s1 := detectors.Result{
-			DetectorType: detectorspb.DetectorType_IbmCloudUserKey,
-			Raw:          []byte(resMatch),
-		}
-
-		if verify {
-			payload := strings.NewReader(`apikey=` + resMatch + `&grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey`)
-			req, err := http.NewRequestWithContext(ctx, "POST", "https://iam.cloud.ibm.com/identity/token", payload)
-			if err != nil {
-				continue
-			}
-			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-			req.Header.Add("Authorization", "Basic Yng6Yng=")
-			res, err := client.Do(req)
-			if err == nil {
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					s1.Verified = true
-				}
-			}
-		}
-
-		results = append(results, s1)
-	}
-
-	return results, nil
-}
 
 func (s Scanner) Type() detectorspb.DetectorType {
 	return detectorspb.DetectorType_IbmCloudUserKey
@@ -75,4 +27,77 @@ func (s Scanner) Type() detectorspb.DetectorType {
 
 func (s Scanner) Description() string {
 	return "IBM Cloud is a suite of cloud computing services from IBM that offers both platform as a service (PaaS) and infrastructure as a service (IaaS). IBM Cloud API keys can be used to access and manage IBM Cloud services and resources."
+}
+
+// Keywords are used for efficiently pre-filtering chunks.
+// Use identifiers in the secret preferably, or the provider name.
+func (s Scanner) Keywords() []string {
+	return []string{"ibm"}
+}
+
+var (
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"ibm"}) + `\b([\w-]{44})\b`)
+)
+
+// FromData will find and optionally verify IbmCloudUserKey secrets in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	// Deduplicate
+	keyMatches := make(map[string]struct{})
+	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		m := match[1]
+		if detectors.StringShannonEntropy(m) < 4 {
+			continue
+		}
+		keyMatches[m] = struct{}{}
+	}
+
+	// Process
+	for key := range keyMatches {
+		r := detectors.Result{
+			DetectorType: detectorspb.DetectorType_IbmCloudUserKey,
+			Raw:          []byte(key),
+		}
+
+		if verify {
+			if s.client == nil {
+				s.client = common.SaneHttpClient()
+			}
+
+			isVerified, vErr := verifyMatch(ctx, s.client, key)
+			r.Verified = isVerified
+			r.SetVerificationError(vErr, key)
+		}
+
+		results = append(results, r)
+	}
+
+	return results, nil
+}
+
+func verifyMatch(ctx context.Context, client *http.Client, key string) (bool, error) {
+	payload := strings.NewReader(`apikey=` + key + `&grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://iam.cloud.ibm.com/identity/token", payload)
+	if err != nil {
+		return false, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Basic Yng6Yng=")
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	default:
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
 }

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -350,6 +350,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/hunter"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/hybiscus"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/hypertrack"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/ibmclouduserkey"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/iconfinder"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/iexapis"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/iexcloud"
@@ -1184,7 +1185,7 @@ func buildDetectorList() []detectors.Detector {
 		&hunter.Scanner{},
 		&hybiscus.Scanner{},
 		&hypertrack.Scanner{},
-		// &ibmclouduserkey.Scanner{},
+		&ibmclouduserkey.Scanner{},
 		&iconfinder.Scanner{},
 		&iexapis.Scanner{},
 		&iexcloud.Scanner{},


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This tidies up the IbmCloudUserKey detector and uncomments it from defaults.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
