### PR TITLE
Fix custom --clone-dir flag

### DIFF
--- a/pkg/detectors/privatekey/privatekey.go
+++ b/pkg/detectors/privatekey/privatekey.go
@@ -80,7 +80,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if err != nil {
 			if !errors.Is(err, errBase64) {
 				logger.V(1).Info("Failed to normalize private key", "err", err)
-				//logger.Error(err, "Failed to normalize private key", "match", match)
 			}
 			continue
 		}

--- a/pkg/sources/github/connector_basicauth.go
+++ b/pkg/sources/github/connector_basicauth.go
@@ -45,5 +45,5 @@ func (c *basicAuthConnector) APIClient() *github.Client {
 }
 
 func (c *basicAuthConnector) Clone(ctx context.Context, repoURL string, dir string, args ...string) (string, *gogit.Repository, error) {
-	return git.CloneRepoUsingToken(ctx, c.password, repoURL, c.username, dir, args...)
+	return git.CloneRepoUsingToken(ctx, c.password, repoURL, dir, c.username, args...)
 }


### PR DESCRIPTION
### Description:
Things should be fetched instead of failing.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
