### PR TITLE
feat: add --print-once flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,8 +75,8 @@ var (
 	includeDetectors     = cli.Flag("include-detectors", "Comma separated list of detector types to include. Protobuf name or IDs may be used, as well as ranges.").Default("all").String()
 	excludeDetectors     = cli.Flag("exclude-detectors", "Comma separated list of detector types to exclude. Protobuf name or IDs may be used, as well as ranges. IDs defined here take precedence over the include list.").String()
 	jobReportFile        = cli.Flag("output-report", "Write a scan report to the provided path.").Hidden().OpenFile(os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
-
-	noVerificationCache = cli.Flag("no-verification-cache", "Disable verification caching").Bool()
+	printOnce            = cli.Flag("print-once", "Only print the first occurrence of a result.").Bool()
+	noVerificationCache  = cli.Flag("no-verification-cache", "Disable verification caching").Bool()
 
 	// Add feature flags
 	forceSkipBinaries  = cli.Flag("force-skip-binaries", "Force skipping binaries.").Bool()
@@ -490,6 +490,7 @@ func run(state overseer.State) {
 		FilterEntropy:            *filterEntropy,
 		Results:                  parsedResults,
 		PrintAvgDetectorTime:     *printAvgDetectorTime,
+		PrintOnce:                *printOnce,
 		ShouldScanEntireChunk:    *scanEntireChunk,
 		VerificationCacheMetrics: &verificationCacheMetrics,
 	}

--- a/pkg/detectors/docker/docker_auth_config.go
+++ b/pkg/detectors/docker/docker_auth_config.go
@@ -87,7 +87,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		var auths map[string]dockerAuth
 		if err := json.NewDecoder(strings.NewReader(match)).Decode(&auths); err != nil {
 			logger.Error(err, "Could not parse Docker auth JSON", "input", match)
-			return results, err
+			continue
 		} else if len(auths) == 0 {
 			continue
 		}

--- a/pkg/detectors/privatekey/privatekey.go
+++ b/pkg/detectors/privatekey/privatekey.go
@@ -79,7 +79,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		key, err := normalizeMatch([]byte(match))
 		if err != nil {
 			if !errors.Is(err, errBase64) {
-				logger.V(1).Info("Failed to normalize private key", "err", err)
+				logger.V(1).Info("Failed to normalize private key", "err", err, "input", match)
 			}
 			continue
 		}

--- a/pkg/sources/github/connector_token.go
+++ b/pkg/sources/github/connector_token.go
@@ -55,7 +55,7 @@ func (c *tokenConnector) Clone(ctx context.Context, repoURL string, dir string, 
 	if err := c.setUserIfUnset(ctx); err != nil {
 		return "", nil, err
 	}
-	return git.CloneRepoUsingToken(ctx, c.token, repoURL, c.user, dir, args...)
+	return git.CloneRepoUsingToken(ctx, c.token, repoURL, dir, c.user, args...)
 }
 
 func (c *tokenConnector) IsGithubEnterprise() bool {

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -724,7 +724,7 @@ func (s *Source) cloneAndScanRepo(ctx context.Context, repoURL string, repoInfo 
 		duration  time.Duration
 		customDir = s.conn.GetCloneDirectory()
 	)
-	if len(s.repoInfoCache.cache) > 1 {
+	if customDir != "" && len(s.repoInfoCache.cache) > 1 {
 		if strings.HasSuffix(customDir, "/") {
 			customDir = path.Join(customDir, repoInfo.owner, repoInfo.name)
 		} else {


### PR DESCRIPTION
### Description:
Add a `--print-once` flag as a follow-up to #29. 

Also include a few misc fixes.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
